### PR TITLE
Change recording framerate to 59.94 fps

### DIFF
--- a/InputDisplay/Config/Config.cs
+++ b/InputDisplay/Config/Config.cs
@@ -123,6 +123,6 @@ namespace InputDisplay
             }
         }
 
-        static public int PlaybackSpeed { get; set; } = 60;
+        static public double PlaybackSpeed { get; set; } = 60/1.001;
     }
 }

--- a/InputDisplay/Core/Animator.cs
+++ b/InputDisplay/Core/Animator.cs
@@ -55,7 +55,7 @@ namespace InputDisplay.Core
 
         public bool Update()
         {
-            int roundedFrame = (int) Math.Floor(this.CurrentFrame);
+            int roundedFrame = (int)Math.Floor(this.CurrentFrame);
 
             //end of inputs reached
             if (roundedFrame >= this.GhostReader.TotalFrames)
@@ -76,7 +76,6 @@ namespace InputDisplay.Core
             if (roundedFrame >= this.GhostReader.Trick_inputs[this.TrickIndex].endFrame)
             {
                 this.TrickIndex += 1;
-
             }
 
             (bool accelerator, bool drift, bool item) actions = this.GhostReader.Face_inputs[this.FaceIndex].values;
@@ -85,7 +84,7 @@ namespace InputDisplay.Core
 
             this.Controller.Update(actions.accelerator, actions.drift, actions.item, coords, trick);
 
-            this.CurrentFrame += (double) Config.PlaybackSpeed / this.Fps;
+            this.CurrentFrame += Config.PlaybackSpeed / this.Fps;
             return true;
         }
 

--- a/InputDisplay/Entities/Timer.cs
+++ b/InputDisplay/Entities/Timer.cs
@@ -25,9 +25,11 @@ namespace InputDisplay.Entities
 
             SolidBrush blackBrush = new SolidBrush(Color.Black);
             g.FillRectangle(blackBrush, new Rectangle(new Point(this.Coords.X, this.Coords.Y), this.Size));
-
-            int actualFrame = (int)Math.Floor(currentFrame) - 240;
-            double seconds = actualFrame * (1.0 / 60.0);
+            // TODO: with a timescale of 16.667ms the final time is quite far off the end time
+            // however having the correct timescale (1/(60.1.001)) also results in weird stuff
+            // Leaving it like this because when having the "correct" scale, time starts at -4.004 which seems weird
+            // Perhaps it'd be better to render the frame number instead
+            double seconds = ((currentFrame) - 240) * (1.0 / 60);
             SolidBrush whiteBrush = new SolidBrush(Color.White);
             g.DrawString(seconds.ToString("0.000", CultureInfo.CreateSpecificCulture("en-CA")), drawFont, whiteBrush, this.Coords.X, this.Coords.Y + 5, new StringFormat());
         }

--- a/InputDisplay/Forms/MainForm.cs
+++ b/InputDisplay/Forms/MainForm.cs
@@ -561,7 +561,7 @@ namespace InputDisplay.Forms
             this.numericUpDown2.Size = new System.Drawing.Size(44, 20);
             this.numericUpDown2.TabIndex = 11;
             this.numericUpDown2.Value = new decimal(new int[] {
-            60,
+            100,
             0,
             0,
             0});

--- a/InputDisplay/Forms/MainForm.cs
+++ b/InputDisplay/Forms/MainForm.cs
@@ -28,7 +28,7 @@ namespace InputDisplay.Forms
         {
             InitializeComponent();
             VariableSetup();
-            this.Animator = new Animator(62.5, this.pictureBox1.ClientSize.Width, this.pictureBox1.ClientSize.Height);
+            this.Animator = new Animator(60/1.001, this.pictureBox1.ClientSize.Width, this.pictureBox1.ClientSize.Height);
             this.AllowDrop = true;
             this.DragEnter += new DragEventHandler(Form1_DragEnter);
             this.DragDrop += new DragEventHandler(Form1_DragDrop);

--- a/InputDisplay/Forms/MainForm.cs
+++ b/InputDisplay/Forms/MainForm.cs
@@ -20,15 +20,14 @@ namespace InputDisplay.Forms
         private CheatDetector CheatDetector;
         private bool GhostLoaded = false;
         private bool Animate = false;
-
-        private Stopwatch stopWatch = new Stopwatch();
         private AccurateTimer timer;
 
         public MainForm()
         {
             InitializeComponent();
             VariableSetup();
-            this.Animator = new Animator(60/1.001, this.pictureBox1.ClientSize.Width, this.pictureBox1.ClientSize.Height);
+            // Set the framerate of the animator to 62.5fps, this may seem weird but a frame lasts exactly 16ms this way
+            this.Animator = new Animator(62.5, this.pictureBox1.ClientSize.Width, this.pictureBox1.ClientSize.Height);
             this.AllowDrop = true;
             this.DragEnter += new DragEventHandler(Form1_DragEnter);
             this.DragDrop += new DragEventHandler(Form1_DragDrop);
@@ -959,10 +958,8 @@ namespace InputDisplay.Forms
 
         private void TimerCallback()
         {
-            this.stopWatch.Stop();
             this.AdvanceAnimator();
             this.pictureBox1.Invalidate();
-            this.stopWatch.Restart();
             return;
         }
 

--- a/InputDisplay/Forms/OptionTabs.cs
+++ b/InputDisplay/Forms/OptionTabs.cs
@@ -61,7 +61,9 @@ namespace InputDisplay.Forms
 
         private void NumericUpDown2_ValueChanged(object sender, EventArgs e)
         {
-            Config.PlaybackSpeed = (int)this.numericUpDown2.Value;
+            // The original playback speed is 59.94(60/1.001) fps
+            // do this weird calculation to properly allow up to 3x speed
+            Config.PlaybackSpeed = 60 * ((double)this.numericUpDown2.Value / 1.001 / 100);
         }
 
         private void NumericUpDown4_ValueChanged(object sender, EventArgs e)

--- a/InputDisplay/Forms/RecordForm.cs
+++ b/InputDisplay/Forms/RecordForm.cs
@@ -49,6 +49,8 @@ namespace InputDisplay.Forms
             this.label2.Visible = false;
             this.progressBar1.Visible = false;
 
+            Animator.Fps = (60 / 1.001); // Set the framerate of the animator to 59.94fps, this matches the framerate of the game
+
             if (Config.PlaybackSpeed == (60/1.001))
             {
                 this.PrepareRecording();

--- a/InputDisplay/Forms/RecordForm.cs
+++ b/InputDisplay/Forms/RecordForm.cs
@@ -49,12 +49,13 @@ namespace InputDisplay.Forms
             this.label2.Visible = false;
             this.progressBar1.Visible = false;
 
-            if (Config.PlaybackSpeed == 60)
+            if (Config.PlaybackSpeed == (60/1.001))
             {
                 this.PrepareRecording();
-            } else
+            } 
+            else
             {
-                this.label1.Text = String.Format("The current playback speed is set to {0} (regular speed is 60)\nAre you sure you want to continue?", Config.PlaybackSpeed);
+                this.label1.Text = String.Format("The current playback speed is set to {0} (regular speed is 100)\nAre you sure you want to continue?", Config.PlaybackSpeed);
             }
         }
 
@@ -151,7 +152,7 @@ namespace InputDisplay.Forms
             // Prepare the animator and write all the frames to the temp directory
             this.Animator.Clear();
             int frameNr = 0;
-            int totalFrames = (int)((double)Math.Ceiling((double)((60.0 / Config.PlaybackSpeed) * this.Animator.Fps)) * this.Animator.GetGhostInfo().Item4);
+            int totalFrames = (int)(Math.Ceiling((((60/1.001) / Config.PlaybackSpeed) * this.Animator.Fps)) * this.Animator.GetGhostInfo().Item4);
             while (this.Animator.Update())
             {
                 // Check for cancel request
@@ -171,7 +172,7 @@ namespace InputDisplay.Forms
             Process proc = new Process();
             proc.StartInfo.FileName = "ffmpeg\\ffmpeg";
             this.FileName = String.Format("{0}.{1}", DateTime.Now.ToString("yy-MM-dd-hh-mm-ss"), this.FileFormat);
-            proc.StartInfo.Arguments = String.Format("-framerate 62.5 -i temp\\%d.png -vcodec {0} {1}", codec, this.FileName);
+            proc.StartInfo.Arguments = String.Format("-r \"60000/1001\" -i temp\\%d.png -vcodec {0} {1}", codec, this.FileName);
             proc.StartInfo.RedirectStandardError = true;
             proc.StartInfo.UseShellExecute = false;
             proc.StartInfo.CreateNoWindow = true;


### PR DESCRIPTION
Currently when recording to a file the framerate is at 62.5fps, which introduces some inaccuracies in video editors.
I maybe should've left all the logic in place to keep it at 60 but technically 59.94(60 frames per 1.001 seconds) is more correct as this is the output framerate of the Wii and also the internal framerate of MKW.
Initially i wanted to rewrite the timer for normal playback as well but this wasn't as simple as i expected it to be so that's why i only set the framerate of the animator to 59.94 there.

Unfortunately i did introduce some bugs with the timer in recordings, the first 2 frames have the exact same time and the end time is close to 2 frames off now, so maybe instead have an option to display framecount instead of framecount converted to time?
ffmpeg also should have a way to burn the timecode into a video so that might be a better approach